### PR TITLE
Add some data persistence to fall back on when getting a null response.

### DIFF
--- a/default.py
+++ b/default.py
@@ -171,6 +171,8 @@ def properties(response,loc):
             if 'forecast' in data['item']:
                 forecast = data['item']['forecast']
                 props_forecast(forecast)        
+    else:
+        clear()
 
 def props_condition(condition,loc):
     set_property('Current.Location'          , loc)

--- a/default.py
+++ b/default.py
@@ -37,7 +37,7 @@ def refresh_locations():
         loc_name = ADDON.getSetting('Location%s' % count)
         if loc_name:
             locations += 1
-        set_property('Location%s' % count, loc_name)
+            set_property('Location%s' % count, loc_name)
     set_property('Locations', str(locations))
     log('available locations: %s' % str(locations))
 

--- a/default.py
+++ b/default.py
@@ -11,7 +11,7 @@ ADDONID      = ADDON.getAddonInfo('id')
 ADDONVERSION = ADDON.getAddonInfo('version')
 CWD          = ADDON.getAddonInfo('path').decode("utf-8")
 RESOURCE     = xbmc.translatePath( os.path.join( CWD, 'resources', 'lib' ).encode("utf-8") ).decode("utf-8")
-DATAPATH     = os.path.join(xbmc.translatePath('special://profile/').decode('utf-8'), 'addon_data', ADDONID)
+DATAPATH     = xbmc.translatePath(ADDON.getAddonInfo('profile')).decode('utf-8')
 
 sys.path.append(RESOURCE)
 

--- a/default.py
+++ b/default.py
@@ -39,7 +39,7 @@ def refresh_locations():
         loc_name = ADDON.getSetting('Location%s' % count)
         if loc_name:
             locations += 1
-            set_property('Location%s' % count, loc_name)
+        set_property('Location%s' % count, loc_name)
     set_property('Locations', str(locations))
     log('available locations: %s' % str(locations))
 

--- a/default.py
+++ b/default.py
@@ -152,9 +152,12 @@ def properties(response, loc, locid):
     
     if response and response.get('query',None) and response['query'].get('results',None) and response['query']['results'].get('channel',None):
         data = response['query']['results']['channel']
+        data['age'] = time.time()
         pickle.dump(data, open(os.path.join(DATAPATH, 'Location' + locid + '.dat'), 'wb'), protocol=0)
     else:
         data = pickle.load(open(os.path.join(DATAPATH, 'Location' + locid + '.dat'), 'r'))
+        if data and (time.time() - data.get('age', 0) > 7200):
+            data = ''
 
     if data:
         condition = ''

--- a/default.py
+++ b/default.py
@@ -25,7 +25,7 @@ WEATHER_WINDOW   = xbmcgui.Window(12600)
 socket.setdefaulttimeout(10)
 
 def log(txt):
-    if isinstance (txt,str):
+    if isinstance (txt, str):
         txt = txt.decode("utf-8")
     message = u'%s: %s' % (ADDONID, txt)
     xbmc.log(msg=message.encode("utf-8"), level=xbmc.LOGDEBUG)
@@ -53,7 +53,7 @@ def location(loc):
     data = parse_data(query)
     if data and data.get('query',None) and data['query'].get('results',None) and data['query']['results'].get('place',None):
         results = data['query']['results']['place']
-        if isinstance (results,list):
+        if isinstance (results, list):
             for item in results:
                 listitem = item['name'] + ' (' + (item['admin1']['content'] + ' - ' if item['admin1'] is not None else '') + item['country']['code'] + ')'
                 location   = item['name'] + ' (' + item['country']['code'] + ')'
@@ -89,7 +89,7 @@ def parse_data(reply):
         log('failed to parse weather data')
     return response
 
-def forecast(loc,locid):
+def forecast(loc, locid):
     log('weather location: %s' % locid)
     retry = 0
     while (retry < 6) and (not MONITOR.abortRequested()):
@@ -173,7 +173,7 @@ def properties(response, loc, locid):
         if 'astronomy' in data:
             astronomy = data['astronomy']
             props_astronomy(astronomy)
-        if ('item' in data):
+        if 'item' in data:
             if 'condition' in data['item']:
                 condition = data['item']['condition']
                 props_condition(condition,loc)
@@ -187,7 +187,7 @@ def properties(response, loc, locid):
     else:
         clear()
 
-def props_condition(condition,loc):
+def props_condition(condition, loc):
     set_property('Current.Location'          , loc)
     set_property('Current.Condition'         , condition['text'].replace('/', ' / '))
     set_property('Current.Temperature'       , condition['temp'])


### PR DESCRIPTION
Store the latest good data for each location that's looked up, add an age value so we know when it's from, and if we get a null response from Yahoo, fall back on that data if it's not too old.  If it is too old, fall back again on calling clear() to populate all the values with the empty defaults.  Too old value arbitrarily set to 2 hours.  Could make it a configurable setting.  Better solution would probably be to refactor the retry code in forecast itself so it could retry several times on null results response... but this seemed like an easier fix.